### PR TITLE
Added stream=True to requests get

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To make sure you don't DDoS CASDA, please make use of the `--max-workers` option
 
 ```console
 get_vis -h
-usage: get_vis [-h] [--output-dir OUTPUT_DIR] [--username USERNAME] [--store-password] [--reenter-password] [--max-workers MAX_WORKERS] sbids [sbids ...]
+usage: vis_download [-h] [--output-dir OUTPUT_DIR] [--username USERNAME] [--store-password] [--reenter-password] [--max-workers MAX_WORKERS] sbids [sbids ...]
 
 Download visibilities from CASDA for a given SBID
 

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -127,7 +127,7 @@ async def download_file(
     msg = f"Downloading from {url}"
     logger.info(msg)
     try:
-        response = await asyncio.to_thread(requests.get, url, timeout=timeout_seconds)
+        response = await asyncio.to_thread(requests.get, url, timeout=timeout_seconds, stream=True)
     except requests.exceptions.Timeout as e:
         msg = "Timed out connecting to server"
         logger.error(msg)


### PR DESCRIPTION
The `requests.get` call does not stream the connection by default. The chunking operation to write the file appeared to only run after the entire file was downloaded. 

Enabling the `stream=True` option should return immediately, and the subsequent `iter_chunk` operates on the buffered result.  