### PR TITLE
Download and write file in separate thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To make sure you don't DDoS CASDA, please make use of the `--max-workers` option
 
 ```console
 get_vis -h
-usage: get_vis [-h] [--output-dir OUTPUT_DIR] [--username USERNAME] [--store-password] [--reenter-password] [--max-workers MAX_WORKERS] sbids [sbids ...]
+usage: vis_download [-h] [--output-dir OUTPUT_DIR] [--username USERNAME] [--store-password] [--reenter-password] [--max-workers MAX_WORKERS] sbids [sbids ...]
 
 Download visibilities from CASDA for a given SBID
 

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -106,6 +106,8 @@ def _download_file(
     timeout_seconds: int = 30,
     chunk_size: int = 1000,
 ) -> Path:
+    """See ``download_file`` function for full documentation.
+    """
 
     try:
         with requests.get(url, timeout=timeout_seconds, stream=True) as response:
@@ -161,13 +163,11 @@ async def download_file(
     msg = f"Downloading from {url}"
     logger.info(msg)
     
-    output_file = await asyncio.to_thread(
+    return await asyncio.to_thread(
         _download_file,
         url=url, output_file=output_file, timeout_seconds=timeout_seconds, chunk_size=chunk_size
     )
     
-    return output_file
-
 async def stage_and_download(
         result_table: Row,
         output_dir: Path,

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -127,7 +127,7 @@ async def download_file(
     msg = f"Downloading from {url}"
     logger.info(msg)
     try:
-        response = await asyncio.to_thread(requests.get, url, timeout=timeout_seconds)
+        response = await asyncio.to_thread(requests.get, url, timeout=timeout_seconds, stream=True)
     except requests.exceptions.Timeout as e:
         msg = "Timed out connecting to server"
         logger.error(msg)

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -126,6 +126,7 @@ async def download_file(
     """
     msg = f"Downloading from {url}"
     logger.info(msg)
+    
     try:
         response = await asyncio.to_thread(requests.get, url, timeout=timeout_seconds, stream=True)
     except requests.exceptions.Timeout as e:
@@ -148,6 +149,10 @@ async def download_file(
 
     msg = f"Downloaded to {output_file}"
     logger.info(msg)
+    
+    # Explicitly close andnd trust nothing
+    response.close()
+    
     return output_file
 
 async def stage_and_download(


### PR DESCRIPTION
This is similar to the other PR I recently raised. 

I noticed some odd activity in `top` around the CPU usage, and the corresponding aggregated download speed was not improving in the way I expected. At least with `rclone` as a benchmark I knew the total network throughput to be a little higher than was I was seeing. This was when I was running `vis_download` with 36 workers for a single SBID, and I was seeing each download peaking at 800kb/s. 

It seems as though the `requests` library is synchronous. Although the `response.get` method was placed in a worker thread, the bit of code iterating over the `response.iter_chunk` was running in the main thread. This little bit of python code and interaction with `requests` was blocking the event loop. The subsequent write method that was placed into the worker thread gave control back to the event loop. 

Why does this matter now?

When using `requests.get(..., stream=False)` the entire file is fetched and stored in memory until the download has finished. Since this was initially in a `to_thread` call we saw the appropriate true network speed at the cost of memory. In turning on `stream=True` to avoid the in-memory buffer and to write out immediately, the synchronous nature of requests is at play.

In this PR I put the whole lot into a single function (e.g. the `get`, the `iter_chunk` and the `write`) into a single function which is then placed into a single worker thread. After this change I was seeing speeds of 5 to 6mb/s for each of the 36 files being downloaded, and much more sustained/stable CPU usage. 