### PR TITLE
Switch to aiohttp in place of requests

### DIFF
--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -136,7 +136,7 @@ async def download_file(
             total_size = int(response.headers.get("content-length", 0)) * 1_000_000
             
             with output_file.open("wb") as file_desc, tqdm(
-                total=total_size, unit="B", unit_scale=True, unit_divisor=chunk_size, desc=output_file.name
+                total=total_size, unit="B", unit_scale=True, unit_divisor=1, desc=output_file.name
             ) as pbar:
                 async for chunk in response.content.iter_chunked(chunk_size):
                     pbar.update(len(chunk) * 1_000_000)

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -5,8 +5,8 @@ import logging
 from pathlib import Path
 from typing import Awaitable, TypeVar, cast
 
+import os
 import aiohttp
-import requests
 from astropy import log as logger
 from astropy.table import Row, Table
 from astroquery.casda import CasdaClass
@@ -167,7 +167,7 @@ async def download_sbid_from_casda(
     result_table: Table = await get_staging_url(sbid)
     
     if output_dir is None:
-        output_dir = Path(os.cwd()) / sbid
+        output_dir = Path(os.getcwd()) / sbid
         output_dir.mkdir(parents=True, exist_ok=True)
     
     coros = []

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -163,9 +163,9 @@ async def download_sbid_from_casda(
     result_table: Table = await get_staging_url(sbid)
     coros = []
     for row in result_table:
-        coros.append(await stage_and_download(row, output_dir, casda))
+        coros.append(stage_and_download(row, output_dir, casda))
 
-    return coros
+    return gather_with_limit(*coros, limit=max_workers)
 
 
 

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -165,6 +165,11 @@ async def download_sbid_from_casda(
         max_workers: int | None = None,
 ) -> list[Path]:
     result_table: Table = await get_staging_url(sbid)
+    
+    if output_dir is None:
+        output_dir = Path(os.cwd()) / sbid
+        output_dir.mkdir(parents=True, exist_ok=True)
+    
     coros = []
     for row in result_table:
         coros.append(stage_and_download(row, output_dir, casda))
@@ -187,9 +192,6 @@ async def get_cutouts_from_casda(
         reenter_password=reenter_password,
     )
 
-    if output_dir is None:
-        output_dir = Path.cwd()
-
     coros = []
     for sbid in sbid_list:
         coros.append(await download_sbid_from_casda(sbid, output_dir, casda, max_workers=max_workers))
@@ -199,7 +201,7 @@ async def get_cutouts_from_casda(
 def main() -> None:
     parser = argparse.ArgumentParser(description="Download visibilities from CASDA for a given SBID")
     parser.add_argument("sbids", nargs="+", type=int, help="SBID to download")
-    parser.add_argument("--output-dir", type=Path, help="Output directory", default=None)
+    parser.add_argument("--output-dir", type=Path, help="Output directory. If unset a directory for each SBID will be created.", default=None)
     parser.add_argument("--username", type=str, help="CASDA username", default=None)
     parser.add_argument("--store-password", action="store_true", help="Store password in keyring")
     parser.add_argument("--reenter-password", action="store_true", help="Reenter password")

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -165,7 +165,7 @@ async def download_sbid_from_casda(
     for row in result_table:
         coros.append(stage_and_download(row, output_dir, casda))
 
-    return gather_with_limit(max_workers, *coros, desc="Download")
+    return await gather_with_limit(max_workers, *coros, desc="Download")
 
 
 

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -132,7 +132,7 @@ async def download_file(
         async with session.get(url) as response:
             assert response.status == 200, f"{response.status=}, not successful"
             
-            total_size = int(response.headers.get("content-length", 0)) * chunk_size
+            total_size = int(response.headers.get("content-length", 0)) * 1_000_000
             
             with output_file.open("wb") as file_desc, tqdm(
                 total=total_size, unit="B", unit_scale=True, unit_divisor=chunk_size, desc=output_file.name

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -167,7 +167,7 @@ async def download_sbid_from_casda(
     result_table: Table = await get_staging_url(sbid)
     
     if output_dir is None:
-        output_dir = Path(os.getcwd()) / sbid
+        output_dir = Path(os.getcwd()) / str(sbid)
         output_dir.mkdir(parents=True, exist_ok=True)
     
     coros = []

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -138,7 +138,7 @@ async def download_file(
                 total=total_size, unit="B", unit_scale=True, unit_divisor=chunk_size, desc=output_file.name
             ) as pbar:
                 async for chunk in response.content.iter_chunked(chunk_size):
-                    pbar.update(len(chunk))
+                    pbar.update(len(chunk) * 1_000_000)
                     file_desc.write(chunk)
                 
     msg = f"Downloaded to {output_file}"

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -104,7 +104,8 @@ async def get_download_url(result_row: Row, casda: CasdaClass) -> str:
 async def download_file(
     url: str,
     output_file: Path,
-    timeout_seconds: int = 30,
+    connect_timeout_seconds: int = 30, 
+    download_timeout_seconds: int = 60*60*12, 
     chunk_size: int = 100000,
 ) -> Path:
     """Download a file from a given URL using asyncio.
@@ -115,8 +116,10 @@ async def download_file(
         URL to download.
     output_file : Path
         Output file path.
-    timeout_seconds : int, optional
-        Seconds to wait for request timeout, by default 30
+    connect_timeout_seconds : int, optional
+        Number of seconds to wait to establish connection. Defaults to 30.
+    download_timeout_seconds : int, optional
+        Allowed length of time to dowload a file, in seconds. Defults to 12 hours.
     chunk_size : int, optional
         Chunks of data to download, by default 1000
 
@@ -128,7 +131,7 @@ async def download_file(
     msg = f"Using aiohttp, Downloading from {url}"
     logger.info(msg)
     
-    timeout = aiohttp.ClientTimeout(total=60*60)
+    timeout = aiohttp.ClientTimeout(total=download_timeout_seconds, connect=connect_timeout_seconds)
     async with aiohttp.ClientSession(timeout=timeout) as session:
         async with session.get(url) as response:
             assert response.status == 200, f"{response.status=}, not successful"

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -128,7 +128,8 @@ async def download_file(
     msg = f"Using aiohttp, Downloading from {url}"
     logger.info(msg)
     
-    async with aiohttp.ClientSession() as session:
+    timeout = aiohttp.ClientTimeout(total=60*60)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
         async with session.get(url) as response:
             assert response.status == 200, f"{response.status=}, not successful"
             

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -136,7 +136,7 @@ async def download_file(
             total_size = int(response.headers.get("content-length", 0))
             
             with output_file.open("wb") as file_desc, tqdm(
-                total=total_size, unit="B", unit_scale=True, unit_divisor=1, desc=output_file.name
+                total=total_size, unit="B", unit_scale=True, unit_divisor=1024, desc=output_file.name
             ) as pbar:
                 async for chunk in response.content.iter_chunked(chunk_size):
                     pbar.update(len(chunk))

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -162,7 +162,7 @@ async def download_sbid_from_casda(
 ) -> list[Path]:
     result_table: Table = await get_staging_url(sbid)
     coros = []
-    async for row in result_table:
+    for row in result_table:
         coros.append(await stage_and_download(row, output_dir, casda))
 
     return coros

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -133,13 +133,13 @@ async def download_file(
         async with session.get(url) as response:
             assert response.status == 200, f"{response.status=}, not successful"
             
-            total_size = int(response.headers.get("content-length", 0)) * 1_000_000
+            total_size = int(response.headers.get("content-length", 0))
             
             with output_file.open("wb") as file_desc, tqdm(
                 total=total_size, unit="B", unit_scale=True, unit_divisor=1, desc=output_file.name
             ) as pbar:
                 async for chunk in response.content.iter_chunked(chunk_size):
-                    pbar.update(len(chunk) * 1_000_000)
+                    pbar.update(len(chunk))
                     file_desc.write(chunk)
                 
     msg = f"Downloaded to {output_file}"

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -138,6 +138,7 @@ async def download_file(
                 total=total_size, unit="B", unit_scale=True, unit_divisor=chunk_size, desc=output_file.name
             ) as pbar:
                 async for chunk in response.content.iter_chunked(chunk_size):
+                    pbar.update(len(chunk))
                     file_desc.write(chunk)
                 
     msg = f"Downloaded to {output_file}"

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -125,7 +125,7 @@ async def download_file(
     IonexError
         If the download times out.
     """
-    msg = f"Downloading from {url}"
+    msg = f"Using aiohttp, Downloading from {url}"
     logger.info(msg)
     
     async with aiohttp.ClientSession() as session:

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -137,7 +137,7 @@ async def download_file(
             with output_file.open("wb") as file_desc, tqdm(
                 total=total_size, unit="B", unit_scale=True, unit_divisor=chunk_size, desc=output_file.name
             ) as pbar:
-                async for chunk in response.content.iter_chunk(chunk_size):
+                async for chunk in response.content.iter_chunked(chunk_size):
                     file_desc.write(chunk)
                 
     msg = f"Downloaded to {output_file}"

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -81,7 +81,7 @@ async def get_download_url(result_row: Row, casda: CasdaClass) -> str:
         str: Download URL
     """
     logger.info("Staging data on CASDA...")
-    url_list: list[str] = await asyncio.to_thread(casda.stage_data, Table(result_row))
+    url_list: list[str] = casda.stage_data(Table(result_row))
 
     good_url_list = []
     for url in url_list:

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -35,7 +35,7 @@ async def gather_with_limit(
         Awaitable: The result of the coroutines
     """
     if limit is None:
-        return cast(list[T], await tqdm.gather(*coros, desc=desc))
+        return cast(list[T], await tqdm.gather(*coros, maxinterval=100000000,  desc=desc))
 
     semaphore = asyncio.Semaphore(limit)
 
@@ -45,7 +45,7 @@ async def gather_with_limit(
 
     return cast(
         list[T],
-        await tqdm.gather(*(sem_coro(c) for c in coros), desc=desc),
+        await tqdm.gather(*(sem_coro(c) for c in coros), maxinterval=100000000, desc=desc),
     )
 
 async def get_staging_url(sbid: int) -> Table:

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -188,9 +188,9 @@ async def get_cutouts_from_casda(
 
     coros = []
     for sbid in sbid_list:
-        coros.append(download_sbid_from_casda(sbid, output_dir, casda, max_workers=max_workers))
+        coros.append(await download_sbid_from_casda(sbid, output_dir, casda, max_workers=max_workers))
     
-    return await gather_with_limit(max_workers, *coros, desc="SBIDs")
+    return coros
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Download visibilities from CASDA for a given SBID")

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -132,7 +132,7 @@ async def download_file(
         async with session.get(url) as response:
             assert response.status == 200, f"{response.status=}, not successful"
             
-            total_size = int(response.headers.get("content-length", 0))
+            total_size = int(response.headers.get("content-length", 0)) * chunk_size
             
             with output_file.open("wb") as file_desc, tqdm(
                 total=total_size, unit="B", unit_scale=True, unit_divisor=chunk_size, desc=output_file.name

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -162,10 +162,10 @@ async def download_sbid_from_casda(
 ) -> list[Path]:
     result_table: Table = await get_staging_url(sbid)
     coros = []
-    for row in result_table:
-        coros.append(stage_and_download(row, output_dir, casda))
+    async for row in result_table:
+        coros.append(await stage_and_download(row, output_dir, casda))
 
-    return await gather_with_limit(max_workers, *coros, desc=f"MSs for SBID {sbid}")
+    return coros
 
 
 

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -105,7 +105,7 @@ async def download_file(
     url: str,
     output_file: Path,
     timeout_seconds: int = 30,
-    chunk_size: int = 1000,
+    chunk_size: int = 100000,
 ) -> Path:
     """Download a file from a given URL using asyncio.
 

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -165,7 +165,7 @@ async def download_sbid_from_casda(
     for row in result_table:
         coros.append(stage_and_download(row, output_dir, casda))
 
-    return gather_with_limit(*coros, limit=max_workers)
+    return gather_with_limit(max_workers, *coros, desc="Download")
 
 
 


### PR DESCRIPTION
This pull request switches over to using `aiohttp` in place of `requests`.  In making the switch I found a nice speed up, and we are able to better handle the chunked writing of the incoming data to the output file. 

I have also increased the base `chunk` size. Increasing this saw a nice little speed bump.