### PR TITLE
Download holography data

### DIFF
--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -208,16 +208,17 @@ async def download_file(
 
 
 async def stage_and_download(
-        result_table: Row,
-        casda: CasdaClass,
-        output_dir: Path | None = None,
-        
+    sbid: int,
+    result_table: Row,
+    casda: CasdaClass,
+    output_dir: Path | None = None,      
 ) -> Path:
     """Trigger CASDA to stage the data, and then download it once
     it has been staged. The `result_table` is generated via the TAQL
     query.
 
     Args:
+        sbid (int): The SBID of the data being downloaded
         result_table (Row): A data time to download, including its url and file name
         casda (CasdaClass): An activate CASDA session that has passed user authentication
         output_dir (Path | None, optional): The location to write the data to. If None data will be downloaded into a folder for the SBID. Defaults to None.

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -113,6 +113,8 @@ async def get_files_to_download(
     Returns:
         Table: Result set of matching files. Should multuple requests be made the intersection of columns between tables is returned.
     """
+    from astropy.table import vstack
+    
     tables: list[Table] = []
     results = await _get_holography_url(sbid=sbid)
     tables.append(results)
@@ -121,7 +123,6 @@ async def get_files_to_download(
         results = await _get_holography_url(sbid=sbid, mode="holography")
         tables.append(results)
     
-    from astropy.table import vstack
     results = vstack(tables, join_type="inner")
     return results
 
@@ -247,7 +248,6 @@ def extract_tarball(in_path: Path) -> Path:
     Returns:
         Path: Directory containing the extracted files
     """
-
     import tarfile
 
     if not tarfile.is_tarfile(in_path):

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -10,7 +10,7 @@ import os
 import aiohttp
 from astropy import log as logger
 from astropy.table import Row, Table
-from astroquery.casda import CasdaClass, Conf
+from astroquery.casda import CasdaClass, conf
 from astroquery.utils.tap.core import TapPlus
 from tqdm.asyncio import tqdm
 

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -70,9 +70,9 @@ from typing import Literal
 async def _get_holography_url(sbid: int, mode: Literal["vis", "holography"] ="vis") -> Table:
     
     if mode == "vis":
-        query_str = f"SELECT TOP 10000 * FROM casda.observation_evaluation_file where sbid='{sbid}'"
+        query_str = f"SELECT TOP 10000 * FROM ivoa.obscore where obs_id='ASKAP-{sbid}'"
     elif mode == "holography":
-        query_str = f"SELECT TOP 10000 * FROM casda.observation_evaluation_file where sbid='{sbid}'"
+        query_str = f"SELECT TOP 10000 * FROM casda.observation_evaluation_file where sbid='{sbid}' and format='calibration'"
     else:
         raise ValueError(f"Unknown {mode=}")
     

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -257,13 +257,12 @@ def extract_tarball(in_path: Path) -> Path:
 
     with tarfile.open(name=in_path, mode="r") as tar:
         for member in tar.getmembers():
+            # Some tarballs have symlinks that point to absolute paths
+            # extractall() falls over on these
             if not member.isfile():
                 continue
             
             tar.extract(member, in_path.parent, filter="data")
-
-    # with tarfile.open(name=in_path) as open_tarfile:
-    #     open_tarfile.extractall(path=in_path.parent, filter="data")
 
     in_path.unlink()
     

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -260,7 +260,7 @@ def extract_tarball(in_path: Path) -> Path:
             if member.islink():
                 continue
             
-            tar.extract(member, in_path.parent)
+            tar.extract(member, in_path.parent, filter="data")
 
     # with tarfile.open(name=in_path) as open_tarfile:
     #     open_tarfile.extractall(path=in_path.parent, filter="data")

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -10,10 +10,9 @@ import os
 import aiohttp
 from astropy import log as logger
 from astropy.table import Row, Table
-from astroquery.casda import CasdaClass
+from astroquery.casda import CasdaClass, Conf
 from astroquery.utils.tap.core import TapPlus
 from tqdm.asyncio import tqdm
-from tqdm import tqdm as sync_tqdm
 
 from vis_downloader.casda_login import login as casda_login
 
@@ -23,6 +22,7 @@ logger.setLevel(logging.INFO)
 
 CASDATAP: TapPlus = TapPlus(url="https://casda.csiro.au/casda_vo_tools/tap")
             
+conf.timeout = 120 # Overwrite the default 20 seconds       
 
 @dataclass
 class DownloadOptions:

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -165,7 +165,7 @@ def get_download_url(result_row: Row, casda: CasdaClass) -> str:
 async def download_file(
     url: str,
     output_file: Path,
-    connect_timeout_seconds: int = 60, 
+    connect_timeout_seconds: int = 120, 
     download_timeout_seconds: int = 60*60*12, 
     chunk_size: int = 1000000,
 ) -> Path:

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -72,7 +72,7 @@ async def _get_holography_url(sbid: int, mode: Literal["vis", "holography"] ="vi
 
     Args:
         sbid (int): The SBID we want files for
-        mode (Literal[&quot;vis&quot;, &quot;holography&quot;], optional): Wheter visibilities or holography will be downloaded. Defaults to "vis".
+        mode (Literal["vis, "holography"], optional): Wheter visibilities or holography will be downloaded. Defaults to "vis".
 
     Raises:
         ValueError: Raised if `mode` is not known
@@ -174,7 +174,7 @@ async def download_file(
     Args:
         url (str): The URL describing the remote resources to download
         output_file (Path): The location to write the file to.
-        connect_timeout_seconds (int, optional): The acceptable amount of time to establish a connection to server. Defaults to 60.
+        connect_timeout_seconds (int, optional): The acceptable amount of time to establish a connection to server. Defaults to 43200.
         download_timeout_seconds (int, optional): The acceptable amoutn of time to wait for the download to finish. Defaults to 60*60*12.
         chunk_size (int, optional): Size of data blocks to store in memory before flushing to disk. Defaults to 1000000.
 

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -257,7 +257,7 @@ def extract_tarball(in_path: Path) -> Path:
 
     with tarfile.open(name=in_path, mode="r") as tar:
         for member in tar.getmembers():
-            if member.islink():
+            if not member.isfile():
                 continue
             
             tar.extract(member, in_path.parent, filter="data")

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -255,8 +255,15 @@ def extract_tarball(in_path: Path) -> Path:
 
     logger.info(f"Extracting {in_path=}")
 
-    with tarfile.open(name=in_path) as open_tarfile:
-        open_tarfile.extractall(path=in_path.parent, filter="data")
+    with tarfile.open(name=in_path, mode="r") as tar:
+        for member in tar.getmembers():
+            if member.islink():
+                continue
+            
+            tar.extract(member, in_path.parent)
+
+    # with tarfile.open(name=in_path) as open_tarfile:
+    #     open_tarfile.extractall(path=in_path.parent, filter="data")
 
     in_path.unlink()
     

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -231,7 +231,7 @@ async def stage_and_download(
         output_dir.mkdir(parents=True, exist_ok=True)
     
     
-    url = await asyncio.to_thread(get_download_url, result_table, casda)
+    url = await asyncio.to_thread(get_download_url, result_row, casda)
     output_file = output_dir / result_row["filename"]
     
     return await download_file(url, output_file)

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -310,7 +310,7 @@ async def get_cutouts_from_casda(
         for row in result_table:
             coros.append(
                 stage_and_download(
-                    sbid=sbid, row=row, output_dir=download_options.output_dir, casda=casda
+                    sbid=sbid, result_row=row, output_dir=download_options.output_dir, casda=casda
                 )
             )
     

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -209,7 +209,7 @@ async def download_file(
 
 async def stage_and_download(
     sbid: int,
-    result_table: Row,
+    result_row: Row,
     casda: CasdaClass,
     output_dir: Path | None = None,      
 ) -> Path:
@@ -219,7 +219,7 @@ async def stage_and_download(
 
     Args:
         sbid (int): The SBID of the data being downloaded
-        result_table (Row): A data time to download, including its url and file name
+        result_row (Row): A data row to download, including its url and file name
         casda (CasdaClass): An activate CASDA session that has passed user authentication
         output_dir (Path | None, optional): The location to write the data to. If None data will be downloaded into a folder for the SBID. Defaults to None.
 
@@ -232,7 +232,7 @@ async def stage_and_download(
     
     
     url = await asyncio.to_thread(get_download_url, result_table, casda)
-    output_file = output_dir / result_table["filename"]
+    output_file = output_dir / result_row["filename"]
     
     return await download_file(url, output_file)
 


### PR DESCRIPTION
This PR has two components:
1 - downloading the calibration metadata of the SBID
2 - a clean up and documentation

On point 1, a new option has been added to optionally download the calibration meta-data for the SBID, which includes the precious holography. This tarball was slightly annoying as it has symlinks pointing to absolute path locations. The conservative `filter="data"` used by the `tarfile.extractall()` method would throw an error on this. I now have something that iterates over members and will only extract files. This seems to produce the appropriate file structure (e.g. sub-directories containing files). But I may have overlooked something. For the moment I say we live with it. 

On point 2, I have gone through a little bit of a restructure, remoing needless functions (that I added when trying to aiohttp it all), added an options class to make adding and passing around new CLI options easier, and have doc-stringed the functions. 