### PR TITLE
Untar things once download finished

### DIFF
--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -208,16 +208,17 @@ async def download_file(
 
 
 async def stage_and_download(
-        result_table: Row,
-        casda: CasdaClass,
-        output_dir: Path | None = None,
-        
+    sbid: int,
+    result_table: Row,
+    casda: CasdaClass,
+    output_dir: Path | None = None,      
 ) -> Path:
     """Trigger CASDA to stage the data, and then download it once
     it has been staged. The `result_table` is generated via the TAQL
     query.
 
     Args:
+        sbid (int): The SBID of the data being downloaded
         result_table (Row): A data time to download, including its url and file name
         casda (CasdaClass): An activate CASDA session that has passed user authentication
         output_dir (Path | None, optional): The location to write the data to. If None data will be downloaded into a folder for the SBID. Defaults to None.

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -113,6 +113,8 @@ async def get_files_to_download(
     Returns:
         Table: Result set of matching files. Should multuple requests be made the intersection of columns between tables is returned.
     """
+    from astropy.table import vstack
+    
     tables: list[Table] = []
     results = await _get_holography_url(sbid=sbid)
     tables.append(results)
@@ -121,7 +123,6 @@ async def get_files_to_download(
         results = await _get_holography_url(sbid=sbid, mode="holography")
         tables.append(results)
     
-    from astropy.table import vstack
     results = vstack(tables, join_type="inner")
     return results
 
@@ -247,7 +248,6 @@ def extract_tarball(in_path: Path) -> Path:
     Returns:
         Path: Directory containing the extracted files
     """
-
     import tarfile
 
     if not tarfile.is_tarfile(in_path):

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -333,7 +333,9 @@ async def get_cutouts_from_casda(
             stage_and_download(
                     sbid=sbid, result_row=row, output_dir=download_options.output_dir, casda=casda
                 ) for row in result_table
-        ])
+            ],
+            max_limit=download_options.max_workers
+        )
         for item in asyncio.as_completed(coros):
             path = await item
             

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -318,8 +318,7 @@ async def get_cutouts_from_casda(
         inner_semaphore = asyncio.Semaphore(12)
         
         async for row in iterator(result_table):
-            async with outer_semaphore:
-                path = await stage_and_download(
+            path = await stage_and_download(
                     sbid=sbid, result_row=row, output_dir=download_options.output_dir, casda=casda
                 )
             async with inner_semaphore:

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -70,9 +70,9 @@ from typing import Literal
 async def _get_holography_url(sbid: int, mode: Literal["vis", "holography"] ="vis") -> Table:
     
     if mode == "vis":
-        query_str = f"SELECT TOP 10000 * FROM casda.observation_evaluation_file where sbid='{sbid}'"
+        query_str = f"SELECT TOP 10000 * FROM ivoa.obscore where obs_id='ASKAP-{sbid}'"
     elif mode == "holography":
-        query_str = f"SELECT TOP 10000 * FROM casda.observation_evaluation_file where sbid='{sbid}'"
+        query_str = f"SELECT TOP 10000 * FROM casda.observation_evaluation_file where sbid='{sbid}' and format='calibration'"
     else:
         raise ValueError(f"Unknown {mode=}")
     

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -321,11 +321,10 @@ async def get_cutouts_from_casda(
             path = await stage_and_download(
                     sbid=sbid, result_row=row, output_dir=download_options.output_dir, casda=casda
                 )
-            async with inner_semaphore:
-                if download_options.extract_tar:
+            if download_options.extract_tar:
                     path = await asyncio.to_thread(extract_tarball, in_path=path)
     
-                paths.append(path)
+            paths.append(path)
                 
     return paths
 

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -310,11 +310,13 @@ async def get_cutouts_from_casda(
             continue
         
         paths = []
+        outer_semaphore = asyncio.Semaphore(download_options.max_workers)
         inner_semaphore = asyncio.Semaphore(12)
-        coros = [stage_and_download(
+        for row in result_table:
+            async with outer_semaphore:
+                path = stage_and_download(
                     sbid=sbid, result_row=row, output_dir=download_options.output_dir, casda=casda
-                ) for row in result_table]
-        async for path in gather_with_limit(coros, as_completed=True):
+                )
             async with inner_semaphore:
                 if download_options.extract_tar:
                     path = await asyncio.to_thread(extract_tarball(in_path=path))

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -257,13 +257,12 @@ def extract_tarball(in_path: Path) -> Path:
 
     with tarfile.open(name=in_path, mode="r") as tar:
         for member in tar.getmembers():
+            # Some tarballs have symlinks that point to absolute paths
+            # extractall() falls over on these
             if not member.isfile():
                 continue
             
             tar.extract(member, in_path.parent, filter="data")
-
-    # with tarfile.open(name=in_path) as open_tarfile:
-    #     open_tarfile.extractall(path=in_path.parent, filter="data")
 
     in_path.unlink()
     

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -260,7 +260,7 @@ def extract_tarball(in_path: Path) -> Path:
             if member.islink():
                 continue
             
-            tar.extract(member, in_path.parent)
+            tar.extract(member, in_path.parent, filter="data")
 
     # with tarfile.open(name=in_path) as open_tarfile:
     #     open_tarfile.extractall(path=in_path.parent, filter="data")

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -271,8 +271,17 @@ def extract_tarball(in_path: Path) -> Path:
     return in_path.parent
 
 
-async def coros_with_limits(coros, max_limit: int):
-    
+async def coros_with_limits(coros: Awaitable[T], max_limit: int) -> Awaitable[T]:
+    """Place a limiter on a set of co-routines via an asynio Semaphore
+
+    Args:
+        coros (Awaitable[T]): The co-routines that will have some limiter placed
+        max_limit (int): The maximum limit of workers
+
+    Returns:
+        Awaitable[T]: New routines with a collective semaphore context applied
+    """
+
     semaphore = asyncio.Semaphore(max_limit)
     
     async def _limit(_coro):

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -21,7 +21,7 @@ T = TypeVar("T")
 logger.setLevel(logging.INFO)
 
 CASDATAP: TapPlus = TapPlus(url="https://casda.csiro.au/casda_vo_tools/tap")
-SEMAPHORES: dict[str, asyncio.Semaphore] = None
+SEMAPHORES: dict[str, asyncio.Semaphore] = {}
 
 conf.timeout = 120 # Overwrite the default 20 seconds       
 

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -314,7 +314,7 @@ async def get_cutouts_from_casda(
         inner_semaphore = asyncio.Semaphore(12)
         for row in result_table:
             async with outer_semaphore:
-                path = stage_and_download(
+                path = await stage_and_download(
                     sbid=sbid, result_row=row, output_dir=download_options.output_dir, casda=casda
                 )
             async with inner_semaphore:

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -165,7 +165,7 @@ def get_download_url(result_row: Row, casda: CasdaClass) -> str:
 async def download_file(
     url: str,
     output_file: Path,
-    connect_timeout_seconds: int = 60, 
+    connect_timeout_seconds: int = 120, 
     download_timeout_seconds: int = 60*60*12, 
     chunk_size: int = 1000000,
 ) -> Path:

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -314,7 +314,7 @@ async def get_cutouts_from_casda(
         coros = [stage_and_download(
                     sbid=sbid, result_row=row, output_dir=download_options.output_dir, casda=casda
                 ) for row in result_table]
-        for path in gather_with_limit(coros, as_completed=True):
+        async for path in gather_with_limit(coros, as_completed=True):
             async with inner_semaphore:
                 if download_options.extract_tar:
                     path = await asyncio.to_thread(extract_tarball(in_path=path))

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -257,7 +257,7 @@ def extract_tarball(in_path: Path) -> Path:
 
     with tarfile.open(name=in_path, mode="r") as tar:
         for member in tar.getmembers():
-            if member.islink():
+            if not member.isfile():
                 continue
             
             tar.extract(member, in_path.parent, filter="data")

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -255,8 +255,15 @@ def extract_tarball(in_path: Path) -> Path:
 
     logger.info(f"Extracting {in_path=}")
 
-    with tarfile.open(name=in_path) as open_tarfile:
-        open_tarfile.extractall(path=in_path.parent, filter="data")
+    with tarfile.open(name=in_path, mode="r") as tar:
+        for member in tar.getmembers():
+            if member.islink():
+                continue
+            
+            tar.extract(member, in_path.parent)
+
+    # with tarfile.open(name=in_path) as open_tarfile:
+    #     open_tarfile.extractall(path=in_path.parent, filter="data")
 
     in_path.unlink()
     

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -272,7 +272,8 @@ def extract_tarball(in_path: Path) -> Path:
     return in_path.parent
 
 async def iterator(items: list[T]) -> T:
-    for item in items:
+    for idx, item in enumerate(items):
+        logger.info(f"Yielding {idx}")
         yield item
 
 async def get_cutouts_from_casda(

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -231,7 +231,7 @@ async def stage_and_download(
         output_dir.mkdir(parents=True, exist_ok=True)
     
     
-    url = await asyncio.to_thread(get_download_url, result_table, casda)
+    url = await asyncio.to_thread(get_download_url, result_row, casda)
     output_file = output_dir / result_row["filename"]
     
     return await download_file(url, output_file)

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -315,7 +315,7 @@ async def get_cutouts_from_casda(
                     sbid=sbid, result_row=row, output_dir=download_options.output_dir, casda=casda
                 ) for row in result_table]
         for path in gather_with_limit(coros, as_completed=True):
-            with inner_semaphore:
+            async with inner_semaphore:
                 if download_options.extract_tar:
                     path = await asyncio.to_thread(extract_tarball(in_path=path))
     

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -338,14 +338,10 @@ async def get_cutouts_from_casda(
             logger.info(path)
             paths.append(path)
         
-        # async for row in iterator(result_table):
-        #     path = await stage_and_download(
-        #             sbid=sbid, result_row=row, output_dir=download_options.output_dir, casda=casda
-        #         )
-        #     if download_options.extract_tar:
-        #             path = await asyncio.to_thread(extract_tarball, in_path=path)
+            if download_options.extract_tar:
+                    path = await asyncio.to_thread(extract_tarball, in_path=path)
     
-        #     paths.append(path)
+            paths.append(path)
                 
     return paths
 

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -310,7 +310,7 @@ async def get_cutouts_from_casda(
         for row in result_table:
             coros.append(
                 stage_and_download(
-                    sbid=sbid, row=row, output_dir=download_options.output_dir, casda=casda
+                    sbid=sbid, result_row=row, output_dir=download_options.output_dir, casda=casda
                 )
             )
     

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -349,9 +349,9 @@ async def get_cutouts_from_casda(
             if download_options.extract_tar:
                     path = await asyncio.to_thread(extract_tarball, in_path=path)
     
-            paths.append(path)
+    #         paths.append(path)
                 
-    return paths
+    # return paths
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Download visibilities from CASDA for a given SBID")

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -10,7 +10,7 @@ import os
 import aiohttp
 from astropy import log as logger
 from astropy.table import Row, Table
-from astroquery.casda import CasdaClass
+from astroquery.casda import CasdaClass, conf
 from astroquery.utils.tap.core import TapPlus
 from tqdm.asyncio import tqdm
 
@@ -21,7 +21,8 @@ T = TypeVar("T")
 logger.setLevel(logging.INFO)
 
 CASDATAP: TapPlus = TapPlus(url="https://casda.csiro.au/casda_vo_tools/tap")
-            
+
+conf.timeout = 120 # Overwrite the default 20 seconds       
 
 @dataclass
 class DownloadOptions:

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -209,7 +209,7 @@ async def download_file(
 
 async def stage_and_download(
     sbid: int,
-    result_table: Row,
+    result_row: Row,
     casda: CasdaClass,
     output_dir: Path | None = None,      
 ) -> Path:
@@ -219,7 +219,7 @@ async def stage_and_download(
 
     Args:
         sbid (int): The SBID of the data being downloaded
-        result_table (Row): A data time to download, including its url and file name
+        result_row (Row): A data row to download, including its url and file name
         casda (CasdaClass): An activate CASDA session that has passed user authentication
         output_dir (Path | None, optional): The location to write the data to. If None data will be downloaded into a folder for the SBID. Defaults to None.
 
@@ -232,7 +232,7 @@ async def stage_and_download(
     
     
     url = await asyncio.to_thread(get_download_url, result_table, casda)
-    output_file = output_dir / result_table["filename"]
+    output_file = output_dir / result_row["filename"]
     
     return await download_file(url, output_file)
 


### PR DESCRIPTION
I wanted two things:
1 - once a download finishes it is untarred straight away
2 - Once a download is finished a new one starts again while obeying the semaphore limit

Added a registry of semaphores should things need to be reused between inner or out loops etc. 