### PR TITLE
Added retry catches around the staging of data

### DIFF
--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -218,7 +218,11 @@ def get_download_url(result_row: Row, casda: CasdaClass) -> str:
         try:
             url_list: list[str] = casda.stage_data(Table(result_row))
             break
-        except (ValueError, requests.exceptions.ConnectionError):
+        except (
+            ValueError,
+            requests.exceptions.ConnectionError,
+            requests.exceptions.ReadTimeout,
+        ):
             logger.warning("Failed to stage. retrying.")
             max_retry -= 1
     else:

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Literal, TypeVar, cast
 
 import aiohttp
 import aiohttp.client_exceptions
+import requests
 from astropy import log as logger
 from astropy.table import Row, Table, vstack
 from astroquery.casda import CasdaClass, conf
@@ -217,7 +218,7 @@ def get_download_url(result_row: Row, casda: CasdaClass) -> str:
         try:
             url_list: list[str] = casda.stage_data(Table(result_row))
             break
-        except ValueError:
+        except (ValueError, requests.Exception.ConnectionError):
             logger.warning("Failed to stage. retrying.")
             max_retry -= 1
     else:

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -222,6 +222,7 @@ def get_download_url(result_row: Row, casda: CasdaClass) -> str:
             ValueError,
             requests.exceptions.ConnectionError,
             requests.exceptions.ReadTimeout,
+            requests.exceptions.HTTPError,
         ):
             logger.warning("Failed to stage. retrying.")
             max_retry -= 1

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -196,7 +196,6 @@ async def get_files_to_download(
     return vstack(tables, join_type="inner")
 
 
-@retry_download
 def get_download_url(result_row: Row, casda: CasdaClass) -> str:
     """Get the download URL for a file on CASDA.
 

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -212,7 +212,16 @@ def get_download_url(result_row: Row, casda: CasdaClass) -> str:
 
     """
     logger.info("Staging data on CASDA...")
-    url_list: list[str] = casda.stage_data(Table(result_row))
+    max_retry = 3
+    while max_retry > 0:
+        try:
+            url_list: list[str] = casda.stage_data(Table(result_row))
+            break
+        except ValueError:
+            logger.warning("Failed to stage. retrying.")
+            max_retry -= 1
+    else:
+        raise ValueError("Failed to stage data too many times.")
 
     good_url_list = []
     for url in url_list:

--- a/src/vis_downloader/async_download.py
+++ b/src/vis_downloader/async_download.py
@@ -218,7 +218,7 @@ def get_download_url(result_row: Row, casda: CasdaClass) -> str:
         try:
             url_list: list[str] = casda.stage_data(Table(result_row))
             break
-        except (ValueError, requests.Exception.ConnectionError):
+        except (ValueError, requests.exceptions.ConnectionError):
             logger.warning("Failed to stage. retrying.")
             max_retry -= 1
     else:


### PR DESCRIPTION
When downloading a larger set of SBIDs (23 in all) I found I would get very occasional exceptions raised from within the astroquery module, ultimately they were raised by `requests`. 

It was unclear to me exactly _why_ they were being raised, as they would eventually be raised even if I were to used 2 or 4 workers. 

At the time there were known issues with acacia and casda, so it could have very well been related to those. 

In any case I do not see the harm in capturing and retrying.